### PR TITLE
feat(spell): automatic setting of spelllang for tex and typ files

### DIFF
--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -49,7 +49,7 @@ vim.api.nvim_create_autocmd("BufWinEnter", {
   callback = function()
     local tex_pattern = "\\usepackage%[[^%]]*n?german[^%]]*%]{babel}"
     local header_lines = 25
-    local desired_lang = "de"
+    local desired_lang = "de,en"
     local main_file = require("utils.spell_utils").get_vimtex_main_file()
     require("utils.spell_utils").apply_spell_language(main_file, tex_pattern, header_lines, desired_lang)
   end,
@@ -60,7 +60,7 @@ vim.api.nvim_create_autocmd("BufWinEnter", {
   callback = function()
     local typ_pattern = '#set%s+text%(lang:%s*"de"%s*%)'
     local header_lines = 25
-    local desired_lang = "de"
+    local desired_lang = "de,en"
     local main_file = require("utils.spell_utils").get_vimtex_main_file()
     require("utils.spell_utils").apply_spell_language(main_file, typ_pattern, header_lines, desired_lang)
   end,

--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -45,8 +45,28 @@ vim.api.nvim_create_autocmd("TermOpen", {
 -- Automatically set spellchecking languages for certain text files
 -- Create an autocommand for both .typ and .tex files that calls the apply_spell_language() function.
 vim.api.nvim_create_autocmd("BufWinEnter", {
-  pattern = { "*.typ", "*.tex" },
+  pattern = { "*.tex" },
   callback = function()
-    require("utils.spell_utils").apply_spell_language()
+    -- require("utils.spell_utils").apply_spell_language_tex()
+    local main_file = require("utils.spell_utils").get_vimtex_main_file()
+    vim.notify("main file: " .. main_file)
   end,
 })
+
+vim.api.nvim_create_autocmd("BufWinEnter", {
+  pattern = { "*.typ" },
+  callback = function()
+    -- require("utils.spell_utils").apply_spell_language_typ()
+    local main_file = require("utils.spell_utils").get_tinymist_main_file()
+    vim.notify("main file: " .. main_file)
+  end,
+})
+
+-- vim.api.nvim_create_autocmd("BufWinEnter", {
+--   pattern = { "*.typ", "*.tex" },
+--   callback = function()
+--     -- require("utils.spell_utils").apply_spell_language()
+--     local main_file = require("utils.spell_utils").get_main_file()
+--     vim.notify("main file: " .. main_file)
+--   end,
+-- })

--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -44,6 +44,8 @@ vim.api.nvim_create_autocmd("TermOpen", {
 
 -- Automatically set spellchecking languages for certain text files
 -- Create an autocommand for both .typ and .tex files that calls the apply_spell_language() function.
+-- Search for pattern in n header lines and set desired lang if pattern is present
+-- with respect to pinned main file
 vim.api.nvim_create_autocmd("BufWinEnter", {
   pattern = { "*.tex" },
   callback = function()

--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -59,9 +59,9 @@ vim.api.nvim_create_autocmd("BufWinEnter", {
   pattern = { "*.typ" },
   callback = function()
     local typ_pattern = '#set%s+text%(lang:%s*"de"%s*%)'
-    local header_lines = 25
+    local header_lines = 10
     local desired_lang = "de,en"
-    local main_file = require("utils.spell_utils").get_vimtex_main_file()
+    local main_file = require("utils.spell_utils").get_tinymist_main_file()
     require("utils.spell_utils").apply_spell_language(main_file, typ_pattern, header_lines, desired_lang)
   end,
 })

--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -41,3 +41,12 @@ vim.api.nvim_create_autocmd("TermOpen", {
     vim.keymap.set("t", "<C-l>", [[<C-\><C-n><C-W>l]], opts)
   end,
 })
+
+-- Automatically set spellchecking languages for certain text files
+-- Create an autocommand for both .typ and .tex files that calls the apply_spell_language() function.
+vim.api.nvim_create_autocmd("BufWinEnter", {
+  pattern = { "*.typ", "*.tex" },
+  callback = function()
+    require("utils.spell_utils").apply_spell_language()
+  end,
+})

--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -47,26 +47,21 @@ vim.api.nvim_create_autocmd("TermOpen", {
 vim.api.nvim_create_autocmd("BufWinEnter", {
   pattern = { "*.tex" },
   callback = function()
-    -- require("utils.spell_utils").apply_spell_language_tex()
+    local tex_pattern = "\\usepackage%[[^%]]*n?german[^%]]*%]{babel}"
+    local header_lines = 25
+    local desired_lang = "de"
     local main_file = require("utils.spell_utils").get_vimtex_main_file()
-    vim.notify("main file: " .. main_file)
+    require("utils.spell_utils").apply_spell_language(main_file, tex_pattern, header_lines, desired_lang)
   end,
 })
 
 vim.api.nvim_create_autocmd("BufWinEnter", {
   pattern = { "*.typ" },
   callback = function()
-    -- require("utils.spell_utils").apply_spell_language_typ()
-    local main_file = require("utils.spell_utils").get_tinymist_main_file()
-    vim.notify("main file: " .. main_file)
+    local typ_pattern = '#set%s+text%(lang:%s*"de"%s*%)'
+    local header_lines = 25
+    local desired_lang = "de"
+    local main_file = require("utils.spell_utils").get_vimtex_main_file()
+    require("utils.spell_utils").apply_spell_language(main_file, typ_pattern, header_lines, desired_lang)
   end,
 })
-
--- vim.api.nvim_create_autocmd("BufWinEnter", {
---   pattern = { "*.typ", "*.tex" },
---   callback = function()
---     -- require("utils.spell_utils").apply_spell_language()
---     local main_file = require("utils.spell_utils").get_main_file()
---     vim.notify("main file: " .. main_file)
---   end,
--- })

--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -37,6 +37,19 @@ Snacks.toggle
   :map("<leader>uy")
 
 
+-- Toggle automatic spell checker language switching
+Snacks.toggle
+  .new({
+    name = "Spell Language Auto Switching",
+    get = function()
+      return require("utils.spell_utils").is_enabled()
+    end,
+    set = function(_)
+      require("utils.spell_utils").toggle()
+    end,
+  })
+  :map("<leader>uk")
+
 -- Add some DAP mappings
 vim.keymap.set("n", "<F5>", function() require("dap").continue() end, { desc = "Debugger: Start" })
 vim.keymap.set("n", "<F6>", function() require("dap").pause() end, { desc = "Debugger: Pause" })

--- a/lua/utils/spell_utils.lua
+++ b/lua/utils/spell_utils.lua
@@ -69,24 +69,17 @@ function M.get_tinymist_main_file()
   -- Try to retrieve the main file from tinymist LSP client
   local current_buf = vim.api.nvim_get_current_buf()
   local tinymist_main = nil
-  local clients = vim.lsp.get_active_clients({ bufnr = current_buf })
-  for _, client in ipairs(clients) do
-    if client.name == "tinymist" then
-      -- Send a synchronous LSP request to get the pinned main file.
-      local params = {} -- no specific parameters needed
-      local response = vim.lsp.buf_request_sync(current_buf, "workspace/executeCommand", {
-        command = "tinymist.getMain",
-        arguments = {},
-      }, 1000)
-      if response then
-        for _, res in pairs(response) do
-          if res.result and type(res.result) == "string" and res.result ~= "" then
-            tinymist_main = res.result
-            break
-          end
-        end
-      end
-      if tinymist_main then
+  local client = vim.lsp.get_clients({ name = "tinymist" })[1]
+
+  -- Send a synchronous LSP request to get the pinned main file.
+  local response = vim.lsp.buf_request_sync(current_buf, "workspace/executeCommand", {
+    command = "tinymist.getMain",
+    arguments = {},
+  }, 1000)
+  if response then
+    for _, res in pairs(response) do
+      if res.result and type(res.result) == "string" and res.result ~= "" then
+        tinymist_main = res.result
         break
       end
     end

--- a/lua/utils/spell_utils.lua
+++ b/lua/utils/spell_utils.lua
@@ -13,10 +13,12 @@ function M.is_enabled()
   return auto_spell_switch_enabled
 end
 
--- Helper function: Search for a given pattern in the first 'max_lines'
--- of the buffer (performance consideration).
--- This can be used for an import pattern in a markup file type, but
--- potentially also for other patterns in any file type.
+------------------------------------------------------------
+-- Helper Functions
+------------------------------------------------------------
+
+-- Search for a given pattern in the first 'max_lines' of the buffer (performance consideration).
+-- This can be used for an import pattern in a markup file type, but potentially also for other patterns in any file type.
 local function find_pattern_in_buffer(max_lines, pattern)
   local lines = vim.api.nvim_buf_get_lines(0, 0, max_lines, false)
   for _, line in ipairs(lines) do
@@ -26,6 +28,75 @@ local function find_pattern_in_buffer(max_lines, pattern)
   end
   return false
 end
+
+-- Read the first n lines from a file at 'filepath'
+local function read_lines_from_file(filepath, n)
+  local ok, lines = pcall(vim.fn.readfile, filepath)
+  if not ok or not lines then
+    return {}
+  end
+  local result = {}
+  for i = 1, math.min(n, #lines) do
+    table.insert(result, lines[i])
+  end
+  return result
+end
+
+-- Search for a given pattern in a table of lines.
+local function find_pattern_in_lines(lines, pattern)
+  for _, line in ipairs(lines) do
+    if line:match(pattern) then
+      return true
+    end
+  end
+  return false
+end
+
+------------------------------------------------------------
+-- Main File Detection for TypSet Systems
+------------------------------------------------------------
+
+function M.get_tinymist_main_file()
+  -- Try to retrieve the main file from tinymist LSP client
+  local current_buf = vim.api.nvim_get_current_buf()
+  local tinymist_main = nil
+
+  -- Send a synchronous LSP request to get the pinned main file.
+  local response = vim.lsp.buf_request_sync(current_buf, "workspace/executeCommand", {
+    command = "tinymist.getMain",
+    arguments = {},
+  }, 1000)
+  if response then
+    for _, res in pairs(response) do
+      if res.result and type(res.result) == "string" and res.result ~= "" then
+        tinymist_main = res.result
+        break
+      end
+    end
+  end
+
+  if tinymist_main then
+    return tinymist_main
+  end
+
+  -- Fallback: return the current buffer's filename if no main file is pinned
+  return vim.api.nvim_buf_get_name(current_buf)
+end
+
+function M.get_vimtex_main_file()
+  -- Check if VimTeX has a main file defined
+  if vim.g.vimtex and vim.g.vimtex.main and vim.fn.filereadable(vim.g.vimtex.main) == 1 then
+    return vim.g.vimtex.main
+  end
+
+  -- Fallback: return the current buffer's filename if no main file is pinned
+  local current_buf = vim.api.nvim_get_current_buf()
+  return vim.api.nvim_buf_get_name(current_buf)
+end
+
+------------------------------------------------------------
+-- Spell Language Application for Each File Type
+------------------------------------------------------------
 
 -- Apply the appropriate spell language based on file type and file content.
 -- For ".typ" files, the first 10 lines are scanned for '#set text(lang: "de")'.
@@ -63,45 +134,6 @@ function M.apply_spell_language()
   -- Otherwise, set the spell language
   vim.cmd("setlocal spell spelllang=" .. desired_lang)
   vim.notify("Activated " .. desired_lang .. " language for spell checking.")
-end
-
-function M.get_tinymist_main_file()
-  -- Try to retrieve the main file from tinymist LSP client
-  local current_buf = vim.api.nvim_get_current_buf()
-  local tinymist_main = nil
-  local client = vim.lsp.get_clients({ name = "tinymist" })[1]
-
-  -- Send a synchronous LSP request to get the pinned main file.
-  local response = vim.lsp.buf_request_sync(current_buf, "workspace/executeCommand", {
-    command = "tinymist.getMain",
-    arguments = {},
-  }, 1000)
-  if response then
-    for _, res in pairs(response) do
-      if res.result and type(res.result) == "string" and res.result ~= "" then
-        tinymist_main = res.result
-        break
-      end
-    end
-  end
-
-  if tinymist_main then
-    return tinymist_main
-  end
-
-  -- Fallback: return the current buffer's filename if no main file is pinned
-  return vim.api.nvim_buf_get_name(current_buf)
-end
-
-function M.get_vimtex_main_file()
-  -- Check if VimTeX has a main file defined
-  if vim.g.vimtex and vim.g.vimtex.main and vim.fn.filereadable(vim.g.vimtex.main) == 1 then
-    return vim.g.vimtex.main
-  end
-
-  -- Fallback: return the current buffer's filename if no main file is pinned
-  local current_buf = vim.api.nvim_get_current_buf()
-  return vim.api.nvim_buf_get_name(current_buf)
 end
 
 return M

--- a/lua/utils/spell_utils.lua
+++ b/lua/utils/spell_utils.lua
@@ -1,0 +1,69 @@
+local M = {}
+
+-- Global flag for auto spell language switching (default is enabled)
+local auto_spell_switch_enabled = true
+
+-- Toggle the spell language auto switching on/off
+function M.toggle()
+  auto_spell_switch_enabled = not auto_spell_switch_enabled
+end
+
+-- Return the current state of auto spell language switching
+function M.is_enabled()
+  return auto_spell_switch_enabled
+end
+
+--
+-- Helper function: Search for a given pattern in the first 'max_lines'
+-- of the buffer (performance consideration).
+-- This can be used for an import pattern in a markup file type, but
+-- potentially also for other patterns in any file type.
+local function find_pattern_in_buffer(max_lines, pattern)
+  local lines = vim.api.nvim_buf_get_lines(0, 0, max_lines, false)
+  for _, line in ipairs(lines) do
+    if line:match(pattern) then
+      return true
+    end
+  end
+  return false
+end
+
+-- Apply the appropriate spell language based on file type and file content.
+-- For ".typ" files, the first 10 lines are scanned for '#set text(lang: "de")'.
+-- For ".tex" files, the first 25 lines are scanned for a \usepackage[...] entry with german options.
+-- Defaults to "en_us". If the current spell language already matches, no action is taken.
+function M.apply_spell_language()
+  if not auto_spell_switch_enabled then
+    return
+  end
+
+  local ext = vim.fn.expand("%:e")
+  local desired_lang = "en_us" -- default language if no match is found
+
+  if ext == "typ" then
+    -- This pattern matches the line:
+    -- #set text(lang: "de")
+    local typ_de_pattern = '#set%s+text%(lang:%s*"de"%s*%)'
+    if find_pattern_in_buffer(10, typ_de_pattern) then
+      desired_lang = "de_de"
+    end
+  elseif ext == "tex" then
+    -- This pattern matches lines like:
+    -- \usepackage[...german...]{babel} or \usepackage[...ngerman...]{babel}
+    local tex_pattern = "\\usepackage%[[^%]]*n?german[^%]]*%]{babel}"
+    if find_pattern_in_buffer(25, tex_pattern) then
+      desired_lang = "de_de"
+    end
+  end
+
+  -- If the desired language is already active, do nothing
+  if vim.bo.spelllang == desired_lang then
+    return
+  end
+
+  -- Otherwise, set the spell language
+  vim.cmd("setlocal spell spelllang=" .. desired_lang)
+  vim.notify("Activated " .. desired_lang .. " language for spell checking.")
+end
+
+return M

--- a/lua/utils/spell_utils.lua
+++ b/lua/utils/spell_utils.lua
@@ -31,6 +31,10 @@ end
 
 -- Read the first n lines from a file at 'filepath'
 local function read_lines_from_file(filepath, n)
+  -- Sanity check: return an empty table if the file does not exist
+  if vim.fn.filereadable(filepath) ~= 1 then
+    return {}
+  end
   local ok, lines = pcall(vim.fn.readfile, filepath)
   if not ok or not lines then
     return {}
@@ -50,6 +54,11 @@ local function find_pattern_in_lines(lines, pattern)
     end
   end
   return false
+end
+
+-- Check if a filepath is already the current buffer
+local function is_current_buffer(filepath)
+  return vim.api.nvim_buf_get_name(0) == filepath
 end
 
 ------------------------------------------------------------
@@ -108,7 +117,7 @@ function M.apply_spell_language(main_file, pattern, header_lines, desired_lang, 
   -- Since we distinguish between file types in the autocmds, we can assume that the file type is correct here.
   -- However, it could still be that main_file is nil, so we need to handle that case.
   local lines = {}
-  if main_file then
+  if main_file and not is_current_buffer(main_file) then
     lines = read_lines_from_file(main_file, header_lines)
   else
     lines = vim.api.nvim_buf_get_lines(0, 0, header_lines, false)


### PR DESCRIPTION
This adds automatic setting of `spelllang` languages based on patterns in header files configured via autocmds. 

An example of automatically applying `"de,en"` as `spelllang` for latex files based on the presence of `\usepackage[(n)german]{babel}` in the first 25 lines of header code:

```lua
vim.api.nvim_create_autocmd("BufWinEnter", {
  pattern = { "*.tex" },
  callback = function()
    local tex_pattern = "\\usepackage%[[^%]]*n?german[^%]]*%]{babel}"
    local header_lines = 25
    local desired_lang = "de,en"
    local main_file = require("utils.spell_utils").get_vimtex_main_file()
    require("utils.spell_utils").apply_spell_language(main_file, tex_pattern, header_lines, desired_lang)
  end,
})
```

It gets the path of the pinned vimtex main file with the current buffer as fallback in case no main file is set.